### PR TITLE
fix: /admin の入口ページを実装して Issue #9 を解消する

### DIFF
--- a/naniwa-ec/app/admin/page.tsx
+++ b/naniwa-ec/app/admin/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+export default async function AdminPage() {
+  // 管理画面の入口では、まず現在のログイン状態を確認する。
+  const supabase = await createClient()
+
+  // 未ログインなら管理者ログイン画面へ案内する。
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect("/admin/login")
+  }
+
+  // ログイン済みでも、管理者以外は管理画面に入れない。
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single()
+
+  // 非管理者は公開側トップへ戻す。
+  if (profile?.role !== "admin") {
+    redirect("/")
+  }
+
+  // 管理者は注文管理を管理画面の入口として使う。
+  redirect("/admin/orders")
+}


### PR DESCRIPTION
Closes #9

## 概要
`app/admin/page.tsx` が空ファイルだったため、`/admin` の page module が成立しておらず build が失敗していた。

そのため、`/admin` を管理画面の入口ページとして実装し、認証状態と権限に応じて適切な画面へ redirect するようにした。

## 変更内容
- `app/admin/page.tsx` を有効な page module として実装
- 未ログイン時は `/admin/login` へ redirect
- 管理者は `/admin/orders` へ redirect
- 非管理者は `/` へ redirect

## 確認
- 簡易テスト済み
 - リダイレクトが正常に遷移する
- `npm run build` を実行し、`app/admin/page.tsx is not a module` エラーが解消されたことを確認

## 補足
- build を進めると、次のエラーとして `app/admin/products/products.tsx` の型エラーが検出される
- これは既存 Issue #10 の対象と重なるため、この PR では扱わない
