### PR TITLE
refactor: 管理者ログインのエラーハンドリングを整理する

### DIFF
--- a/naniwa-ec/app/admin/login/page.tsx
+++ b/naniwa-ec/app/admin/login/page.tsx
@@ -9,18 +9,31 @@ export default function AdminLoginPage() {
   const [loading, setLoading] = useState(false)
 
   const handleLogin = async () => {
+    // 新しいログイン試行の前に、前回のエラー表示を消す。
     setErrorMsg("")
     setLoading(true)
-    const result = await login(email, password)
-    setLoading(false)
-    if (result.error) {
-      setErrorMsg("メールアドレスまたはパスワードが正しくありません")
-    } else {
+
+    try {
+      const result = await login(email, password)
+
+      // 認証失敗は想定内エラーなので、従来どおり result.error で扱う。
+      if (result.error) {
+        setErrorMsg("メールアドレスまたはパスワードが正しくありません")
+        return
+      }
+
       window.location.href = "/admin/orders"
+    } catch {
+      // 通信失敗や server action 側の例外など、想定外エラーはここで表示する。
+      setErrorMsg("ログイン処理中にエラーが発生しました。時間をおいて再度お試しください。")
+    } finally {
+      // 成功・失敗に関係なく、最後に必ず送信中状態を解除する。
+      setLoading(false)
     }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Enter キーでもボタン押下と同じログイン処理を呼び出す。
     if (e.key === 'Enter') handleLogin()
   }
 


### PR DESCRIPTION
Closes #25

## 概要
管理者ログイン画面の `handleLogin` では `await login(email, password)` を実行していたが、
想定外エラーに対する `try-catch-finally` の処理がなく、例外発生時の画面状態が不安定になる余地があった。
例えば、通信エラー時にsupabaseから返ってこない場合、リロードの状態が変更されず無限リロード状態となる可能性があった。

そのため、認証失敗と想定外エラーを分けて扱えるようにし、
成功・失敗に関係なく `loading` 状態が解除されるよう整理した。

## 変更内容
- `app/admin/login/page.tsx` の `handleLogin` を `try-catch-finally` 構成に変更
- `result.error` は想定内の認証失敗として従来どおり扱う
- 想定外エラー時に利用者向けメッセージを表示する処理を追加
- `finally` で `loading` を必ず解除するよう修正
- 処理意図が分かるコメントを追加

## 確認済み
- 認証失敗時に既存のエラーメッセージが表示されること
- 想定外エラー時に別メッセージが表示されること　※下記の通り仮想的に例外エラーを発生させ確認
 - `const result = await login(email, password)
throw new Error("forced error for catch test")
`
- どちらの場合でも `loading` が解除され、再操作できること